### PR TITLE
- db fix

### DIFF
--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -293,9 +293,10 @@ class DB
      *
      * @see Adapter::escape()
      * @param array|string $mixed Target to escape
+     * @param bool $leaveQuotes Should leave quotes after escape?
      * @return array|string
      */
-    public static function escape($mixed)
+    public static function escape($mixed, bool $leaveQuotes = false)
     {
         if (is_array($mixed)) {
             foreach ($mixed as $index => $str) {
@@ -305,7 +306,7 @@ class DB
             return $mixed;
         }
 
-        return static::$db->escape($mixed);
+        return static::$db->escape($mixed, $leaveQuotes);
     }
 
     /**

--- a/src/Core/DB/Adapter.php
+++ b/src/Core/DB/Adapter.php
@@ -104,9 +104,10 @@ interface Adapter
      * Escapes string
      *
      * @param string $str String to escape
+     * @param bool $leaveQuotes Should leave quotes after escape?
      * @return string Escaped string
      */
-    public function escape(string $str): string;
+    public function escape(string $str, bool $leaveQuotes = false): string;
 
     /**
      * Returns amount of affected rows by the last executed statement

--- a/src/Core/DB/MySQL.php
+++ b/src/Core/DB/MySQL.php
@@ -179,8 +179,13 @@ class MySQL implements Adapter
         }
     }
 
-    public function escape(string $str): string
+    public function escape(string $str, bool $leaveQuotes = false): string
     {
+        $q = $this->db->quote($str);
+        if ($leaveQuotes) {
+            return $q;
+        }
+
         return substr($this->db->quote($str), 1, -1);
     }
 

--- a/src/Core/DB/MySQLi.php
+++ b/src/Core/DB/MySQLi.php
@@ -124,7 +124,7 @@ class MySQLi implements Adapter
         return $n > 0 ? 'Ошибка. Код: ' . $n . '. ' . (isset($errs[$n]) ? $errs[$n] : mysqli_error($this->link)) : '';
     }
 
-    public function escape(string $str): string
+    public function escape(string $str, bool $leaveQuotes = false): string
     {
         return mysqli_escape_string($this->link, $str);
     }


### PR DESCRIPTION
An optional argument to the DB::escape() and Adapter functions. If set to true, will return a string with quotation marks (usually not needed, but appears to be required in Team for some cases)