### PR TITLE
- fixed authentication in API

### DIFF
--- a/src/Core/Api/Json.php
+++ b/src/Core/Api/Json.php
@@ -9,7 +9,10 @@ class Json extends Base
         $response = new JsonResponse();
 
         try {
-            static::auth();
+            if ($this->requireAuth) {
+                $this->user = $this->assertAuthenticated();
+            }
+
             $response->setData($this->{$this->getMethodName()}($request, $response));
         } catch (\Throwable $ex) {
             $response->setError($ex);

--- a/src/Core/DB/Schema/Column.php
+++ b/src/Core/DB/Schema/Column.php
@@ -51,6 +51,7 @@ class Column extends TableElementBase
     public function autoIncrement(bool $v = true): self
     {
         $this->params->autoIncrement = $v;
+        $this->params->isNull = false;
         return $this;
     }
 
@@ -63,6 +64,12 @@ class Column extends TableElementBase
     public function collate(string $collation): self
     {
         $this->params->collate = $collation;
+        return $this;
+    }
+
+    public function primaryKey(): self
+    {
+        $this->params->isPrimaryKey = true;
         return $this;
     }
 
@@ -98,6 +105,10 @@ class Column extends TableElementBase
         if ($this->params->default) {
             $sql .= 'DEFAULT '
                 . (is_string($this->params->default) ? DB::wrapString($this->params->default) : $this->params->default);
+        }
+
+        if ($this->params->isPrimaryKey) {
+            $sql .= 'PRIMARY KEY ';
         }
 
         if ($this->params->autoIncrement) {

--- a/src/Core/DB/Schema/Constraint.php
+++ b/src/Core/DB/Schema/Constraint.php
@@ -61,17 +61,21 @@ class Constraint extends ElementBase
      * References column(s) in another table
      *
      * @param string $referenceTable Target reference table
-     * @param array $colToReference Associative array of my_column => their_column
+     * @param string|array $colToReference Associative array or string of my_column => their_column
      * @return $this
      */
-    public function foreignKey(string $referenceTable, array $colToReference): self
+    public function foreignKey(string $referenceTable, $colToReference): self
     {
         $columns = [];
         $referenceColumns = [];
 
-        foreach ($colToReference as $column => $reference) {
-            $columns[] = $column;
-            $referenceColumns[] = $reference;
+        if (is_array($colToReference)) {
+            foreach ($colToReference as $column => $reference) {
+                $columns[] = $column;
+                $referenceColumns[] = $reference;
+            }
+        } else {
+            $columns = $referenceColumns = [$colToReference];
         }
 
         $this->params->isUnique = $this->params->isPrimary = false;

--- a/src/Core/DB/Schema/Params/ColumnParams.php
+++ b/src/Core/DB/Schema/Params/ColumnParams.php
@@ -8,4 +8,5 @@ class ColumnParams
     public $autoIncrement = false;
     public $comment = '';
     public $collate = '';
+    public $isPrimaryKey = false;
 }


### PR DESCRIPTION
- added assertAuthenticated() to get authenticated user or throw an exception
- added primaryKey() method to Column to simplify migration code
- autoIncrement() now implicitly sets isNull to false
- changed foreightKey()'s colToReference argument to support string if both foreign and current column have the same name